### PR TITLE
Make Google font compatible with HTTPS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,7 @@
  *= require_self
  */
 
-@import url(http://fonts.googleapis.com/css?family=Oswald:300);
+@import url(//fonts.googleapis.com/css?family=Oswald:300);
 
 body {
   font-family: 'Helvetica Neue', arial;


### PR DESCRIPTION
Remove the "http" from the beginning of the Google font URL so that it is compatible with both HTTP and HTTPS.